### PR TITLE
Update Payment Status for Failed payments

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -274,7 +274,6 @@ class Extension extends AbstractPluginIntegration {
 		$should_update = ! MemberPress::transaction_has_status(
 			$transaction,
 			array(
-				MeprTransaction::$failed_str,
 				MeprTransaction::$complete_str,
 			)
 		);


### PR DESCRIPTION
In some payment gateways, the buyer can retry the failed payment. So, it's important to update status in memberpress also if payment is now complete.