### PR TITLE
Don't send signup notices for recurring payments.

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -555,7 +555,9 @@ class Extension extends AbstractPluginIntegration {
 				 *
 				 * @link https://github.com/wp-premium/memberpress/blob/1.9.21/app/lib/MeprUtils.php#L1361-L1390
 				 */
-				MeprUtils::send_signup_notices( $memberpress_transaction );
+				if ( 'recurring' !== $payment->get_meta( 'mollie_sequence_type' ) ) {
+					MeprUtils::send_signup_notices( $memberpress_transaction );
+				}
 
 				/**
 				 * Send transaction receipt notices.


### PR DESCRIPTION
Fix #9.

Check for recurring sequence type was inspired by the way we do this elsewhere in the extension:

https://github.com/pronamic/wp-pronamic-pay-memberpress/blob/c4f4ecaaba5ac89e53705e24e360bf8328feb835/src/Extension.php#L296