### PR TITLE
No longer ignore "Pronamic" payment method when updating MemberPress subscription gateway

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -263,8 +263,17 @@ class Extension extends AbstractPluginIntegration {
 				continue;
 			}
 
-			if ( $memberpress_gateway->get_payment_method() === $payment->get_payment_method() ) {
-				$memberpress_subscription->gateway = $memberpress_gateway->id;
+			$gateway_method = $memberpress_gateway->get_payment_method();
+			$payment_method = $payment->get_payment_method();
+
+			if ( ! \in_array( $gateway_method, [ null, $payment_method ] ) ) {
+				continue;
+			}
+
+			$memberpress_subscription->gateway = $memberpress_gateway->id;
+
+			if ( $gateway_method === $payment_method ) {
+				break;
 			}
 		}
 


### PR DESCRIPTION
Fix #22.

ℹ️ The `break` causes an exactly matching payment method to have priority over the Pronamic payment method:

```php
			if ( $gateway_method === $payment_method ) {
				break;
			}
```