### PR TITLE
Set `is_subscription_change` payment meta for gateways to recognise subscription changes

### DIFF
--- a/src/Pronamic.php
+++ b/src/Pronamic.php
@@ -155,6 +155,13 @@ class Pronamic {
 		}
 
 		/*
+		 * Upgrade / downgrade.
+		 */
+		if ( $memberpress_transaction->is_upgrade_or_downgrade() ) {
+			$payment->set_meta( 'is_subscription_change', true );
+		}
+
+		/*
 		 * Return.
 		 */
 		return $payment;


### PR DESCRIPTION
Fix #31.