### PR TITLE
Allow woocommerce/action-scheduler ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
 		"php": ">=8.2",
 		"automattic/jetpack-autoloader": "^5.0",
 		"pronamic/wp-number": "^1.4",
-		"woocommerce/action-scheduler": "^3.4",
+		"woocommerce/action-scheduler": "^3.4 || ^4.0",
 		"wp-pay/core": "^4.9"
 	},
 	"require-dev": {


### PR DESCRIPTION
Update the `woocommerce/action-scheduler` Composer constraint to also allow the new 4.0 branch using an OR operator.